### PR TITLE
Support literals

### DIFF
--- a/doc/source/errors.rst
+++ b/doc/source/errors.rst
@@ -192,3 +192,15 @@ original enum class and  will suggest fixes to the typos. Additionally
     The above exception was the direct cause of the following exception:
     ...
     WrongListItemError: Cannot process item 2 into 'DiskPermissions'.
+
+Wrong Literals
+--------------
+
+Wrong Literals provide an exception with the tested and valid values::
+
+    >>> import validobj
+    >>> import typing
+    >>> validobj.parse_input(5, typing.Literal[6, typing.Literal[7], 8])
+    Traceback (most recent call last):
+    ...
+    WrongLiteralError: Wrong literal. Expecting one of '[6, 7, 8]'. Got '5'

--- a/doc/source/inout.rst
+++ b/doc/source/inout.rst
@@ -128,6 +128,15 @@ If a given input can be coerced into more than one of the member of the union, t
     >>> validobj.parse_input([1,2,3], typing.Union[set, tuple])
     {1, 2, 3}
 
+Literals
+^^^^^^^^
+
+:py:class:`typing.Literal` is supported with recent enough versions of the typing module::
+
+    >>> validobj.parse_input(5, typing.Literal[1, 2, typing.Literal[5]])
+    5
+
+
 
 Any
 ^^^

--- a/validobj/errors.py
+++ b/validobj/errors.py
@@ -199,3 +199,18 @@ class WrongListItemError(ValidationError):
     def __init__(self, *args, wrong_index, **kwargs):
         self.wrong_index = wrong_index
         super().__init__(*args, **kwargs)
+
+
+class WrongLiteralError(ValidationError):
+    """"Exception raised when some literal is incorrect"""
+
+    def __init__(self, value, reference):
+        self.value = value
+        self.reference = reference
+        super().__init__(value, reference)
+
+    def __str__(self):
+        return (
+            f"Wrong literal. Expecting {'one of ' if len(self.reference) > 1 else ''}"
+            f"'{self.reference!r}'. Got '{self.value!r}'"
+        )

--- a/validobj/tests/test_validation.py
+++ b/validobj/tests/test_validation.py
@@ -2,6 +2,13 @@ import dataclasses
 import enum
 from typing import Tuple, Set, List, Mapping, Any, Union, Callable, NewType
 
+try:
+    from typing import Literal
+except ImportError: # pragma: nocover
+    HAVE_LITERAL = False
+else:
+    HAVE_LITERAL = True
+
 import pytest
 from hypothesis import given
 from hypothesis.strategies import builds, register_type_strategy, booleans
@@ -136,7 +143,12 @@ dbstrat = builds(Db).map(invert_db)
 def test_arbitrary_valid(db):
     parse_input(db, Db)
 
+
 def test_none():
     assert parse_input(None, None) is None
     with pytest.raises(ValidationError):
         parse_input("Some value", None)
+
+@pytest.mark.skipif(not HAVE_LITERAL, reason="Literal not found")
+def test_literal():
+    assert parse_input(5, Literal[5, Literal[1, 3]]) == 5


### PR DESCRIPTION
I want to use Literals, but also Python 3.7, so support them
conditionally.

Doctests are disabled for that reason.