### PR TITLE
Add support for custom validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,11 @@ https://validobj.readthedocs.io/en/latest/
 	#
 	```
 
-The set of applied transformations is [described in the
-documentation](https://validobj.readthedocs.io/en/latest/inout.html)
+The set of [applied
+transformations](https://validobj.readthedocs.io/en/latest/inout.html) as well
+as the interface to [customise
+processing](https://validobj.readthedocs.io/en/latest/custom.html) are described
+in the [documentation](https://validobj.readthedocs.io/en/latest)
 
 
 

--- a/doc/source/apisrc/validobj.rst
+++ b/doc/source/apisrc/validobj.rst
@@ -1,16 +1,16 @@
 validobj package
 ================
 
-Submodules
-----------
+Module contents
+---------------
 
-validobj.errors module
-----------------------
-
-.. automodule:: validobj.errors
+.. automodule:: validobj
    :members:
    :undoc-members:
    :show-inheritance:
+
+Submodules
+----------
 
 validobj.validation module
 --------------------------
@@ -21,10 +21,19 @@ validobj.validation module
    :show-inheritance:
 
 
-Module contents
----------------
+validobj.errors module
+----------------------
 
-.. automodule:: validobj
+.. automodule:: validobj.errors
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+validobj.custom module
+----------------------
+
+.. automodule:: validobj.custom
    :members:
    :undoc-members:
    :show-inheritance:

--- a/doc/source/custom.rst
+++ b/doc/source/custom.rst
@@ -1,0 +1,117 @@
+.. _custom:
+
+Defining custom parsers
+=======================
+
+.. testsetup::
+
+    import typing
+
+    import validobj
+
+
+
+Validobj provides a mechanism to allow supplementing the predefined processing
+logic. It consist on annotating a type with a function to be invoked to process
+the input. It uses :py:class:`typing.Annotated` under the hood, so the
+resulting annotations might be processed by static type checkers.
+
+A simple way to use the functionality is as follows
+
+1. Define a function with one input with the processing logic.
+2. Add type annotations to the input parameter and return type.
+3. Wrap the function with :py:func:`validobj.custom.Parser` to create a type annotation.
+4. Use the type annotation with Validobj.
+
+
+For example
+
+.. doctest::
+    :pyversion: >= 3.9
+
+    >>> from validobj.custom import Parser
+    >>> from validobj import parse_input, ValidationError
+    >>> def make_range(a, b):
+    ...     def parser(n: float) -> float:
+    ...         if not a <= n < b:
+    ...             raise ValidationError(f"Expecting {a} <= n < {b}, but n={n}")
+    ...         return n
+    ...     return parser
+    ... 
+    >>> RangeFloat = Parser(make_range(0, 10))
+    >>> parse_input(3.14, RangeFloat)
+    3.14
+    >>> parse_input(-0.1, RangeFloat) #doctest: +SKIP
+    Traceback (most recent call last):
+    ...
+    ValidationError: Expecting 0 <= n < 10, but n=-0.1
+
+The custom function should raise an instance of
+:py:class:`validobj.errors.ValidationError` to indicate validation failure.
+Other exceptions will be treated as programming errors.
+
+The Validobj :ref:`logic <inout>` is used to cast the input into the type
+annotated in the input parameter. The custom function will only be called if
+the cast succeeds. The return annotation of the custom function is not checked
+or enforced by Validobj, but might be useful for static type checkers.
+
+
+.. doctest::
+    :pyversion: >= 3.9
+
+    >>> import dataclasses
+    >>> @dataclasses.dataclass
+    ... class Point:
+    ...     x: float
+    ...     y: float
+    ... 
+    >>> def in_unit_circle_point(p: Point) -> Point:
+    ...     if not p.x**2 + p.y**2 < 1:
+    ...         raise ValidationError("Point outside unit circle")
+    ...     return p
+    ... 
+    >>> UnitCirclePoint = Parser(in_unit_circle_point)
+    >>> def in_unit_circle_point(p: Point):
+    ...     if not p.x**2 + p.y**2 < 1:
+    ...         raise ValidationError("Point outside unit circle")
+    ...     return p
+    >>> parse_input({"x": 0.4, "y": 0.2}, UnitCirclePoint)
+    Point(x=0.4, y=0.2)
+    >>> parse_input({"x": 0.4, "y": "ups"}, UnitCirclePoint) #doctest: +SKIP
+    Traceback (most recent call last):
+    ...
+    WrongFieldError: Cannot process field 'y' of value into the corresponding field of 'Point'
+    >>> parse_input({"x": 0.4, "y": 0.98}, UnitCirclePoint) #doctest: +SKIP
+    Traceback (most recent call last):
+    ...
+    ValidationError: Point outside unit circle
+
+
+While the result of :py:func:`validobj.custom.Parser` is an annotation
+compatible with static type checkers, they might dislike the fact that it is
+generated dynamically. If that is an important use case, the workaround is to
+define the type annotation explicitly manually.
+:py:func:`validobj.custom.Parser` returns::
+
+    typing.Annotated[
+        <return type>,
+        validobj.custom.InputType(
+            <input type of parameter>
+        ),
+        validobj.custom.Validator(
+            <function>
+        )
+    ]
+
+That is, the two metadata parameters
+accompanying the type of the processed object should be the type of the input
+wrapped in :py:class:`validobj.custom.InputType` and the function doing the
+validation, wrapped in :py:class:`validobj.custom.Validator`.
+
+.. doctest::
+    :pyversion: >= 3.9
+
+    >>> from validobj.custom import InputType, Validator
+    >>> UnitCirclePoint = typing.Annotated[Point, InputType(Point), Validator(in_unit_circle_point)]
+    >>> parse_input({"x": 0.4, "y": 0.5}, UnitCirclePoint)
+    Point(x=0.4, y=0.5)

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -4,8 +4,8 @@ Welcome to Validobj's documentation!
 
 Validobj is a library that processes semistructured input coming from sources a
 JSON mapping or a YAML configuration file  into more structured Python objects.
-Currently it only has one API function, :py:func:`validobj.validation.parse_input`, but it
-can do quite a bit!
+The main API function, :py:func:`validobj.validation.parse_input`, takes care
+of that
 
 .. literalinclude:: ../examples/basic.py
 
@@ -15,7 +15,7 @@ and output <inout>`.
 
 Validobj aims at providing building blocks to construct the most human friendly
 error handling in town. Its exceptions provide lots of information on what went
-wrong as well as good error messages, which even contain suggestions on typos.
+wrong as well as good messages, which even contain suggestions on typos.
 
 .. doctest::
 
@@ -41,12 +41,17 @@ wrong as well as good error messages, which even contain suggestions on typos.
     ...
     WrongListItemError: Cannot process item 2 into 'DiskPermissions'.
 
+When more control is needed, Validobj allows :ref:`passing custom functions to
+handle transformations <custom>`.
+
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
 
    inout
    errors
+   custom
    examples
    apisrc/modules
 

--- a/doc/source/inout.rst
+++ b/doc/source/inout.rst
@@ -109,7 +109,7 @@ made homogeneous:
 Unions
 ^^^^^^
 
-:py:class:`typing.Union` and :py:class:`typing.Optional` are supported:
+:py:data:`typing.Union` and :py:data:`typing.Optional` are supported:
 
 .. doctest::
 
@@ -140,17 +140,29 @@ From Python 3.10, union types can be specified using the ``X | Y`` syntax.
 Literals
 ^^^^^^^^
 
-:py:class:`typing.Literal` is supported with recent enough versions of the typing module::
+:py:data:`typing.Literal` is supported with recent enough versions of the typing module::
 
     >>> validobj.parse_input(5, typing.Literal[1, 2, typing.Literal[5]])
     5
 
 
+Annotaded
+^^^^^^^^^
+
+:py:data:`typing.Annotated` is used to enable :ref:`custom processing <custom>`
+of types. Other annotation metadata  is ignored.
+
+
+.. doctest::
+    :pyversion: >= 3.9
+
+    >>> validobj.parse_input(5, typing.Annotated[int, "bogus"])
+    5
 
 Any
 ^^^
 
-:py:class:`typing.Any` is a no-op:
+:py:data:`typing.Any` is a no-op:
 
 
 .. doctest::

--- a/validobj/custom.py
+++ b/validobj/custom.py
@@ -1,0 +1,118 @@
+"""Tools for :ref:`custom validation <custom>` of types.
+
+.. testsetup::
+
+    import typing
+
+    from validobj.custom import Parser
+
+"""
+from typing import Annotated, Any, Type, Callable
+import functools
+import inspect
+
+
+__all__ = ["InputType", "Validator", "Parser"]
+
+
+class InputType:
+    """A wrapper over an input type, for use in the  :ref:`custom <custom>` processing.
+
+    Parameters
+    ----------
+    type : Type
+        The wrapped type.
+    """
+
+    def __init__(self, type: Type):
+        self.type = type
+
+    def __repr__(self):
+        return f'{self.__class__.__name__}({repr(self.type)})'
+
+
+class Validator:
+    """A wrapper over a validation function, for use in the  :ref:`custom <custom>`
+    processing.
+
+    Parameters
+    ----------
+    func : Callable
+        The wrapped function.
+    """
+
+    def __init__(self, func: Callable):
+        self.func = func
+        functools.update_wrapper(self, func)
+
+    def __call__(self, *args, **kwargs):
+        return self.func(*args, **kwargs)
+
+    def __repr__(self):
+        return f'{self.__class__.__name__}({repr(self.func)})'
+
+
+def Parser(func: Callable):
+    """
+    Read the type annotations of ``func`` and return a
+    :py:class:`typing.Annotated` with the function's return type as the set
+    type and the requisite metadata so that ``func`` is used by
+    :py:func:`validobj.parse_input`.
+
+
+    Parameters
+    ----------
+    func : Callable
+        The wrapped function. It should have one positional parameter. If the
+        parameter is annotated, Validobj will cast the input consitently with
+        the annotation before presenting it to the function.
+
+    Returns
+    -------
+    annotated : :py:data:`typing._AnnotatedAlias`
+        Annotation of the return type of the function with two metadata parameters:
+        :py:class:`InputType` with the type annotation of the first parameter and
+        :py:class:`Validator` with the function itself.
+
+    Notes
+    -----
+    While the returned annotation is compatible with static type checker, the
+    runtime call to this function to produce it is not. Write the
+    :py:data:`typing.Annotated` manually if that is important.
+
+    Examples
+    --------
+
+    Add support for :py:class:`decimal.Decimal`.
+
+    .. doctest::
+        :pyversion: >= 3.9
+
+        >>> import typing
+        >>> import decimal
+        >>> def to_decimal(inp: typing.Union[str, int, float]) -> decimal.Decimal:
+        ...     try:
+        ...         return decimal.Decimal(inp)
+        ...     except decimal.InvalidOperation as e:
+        ...         raise ValidationError("Invalid decimal") from e
+        ...
+        >>> from validobj.custom import Parser
+        >>> Decimal = Parser(to_decimal)
+        >>> print(Decimal)
+        typing.Annotated[decimal.Decimal, InputType(typing.Union[str, int, float]), Validator(<function to_decimal at 0x7f5d077b55e0>)]
+        >>> from validobj import parse_input, ValidationError
+        >>> parse_input(0.5, Decimal)
+        Decimal('0.5')
+    """
+    s = inspect.signature(func)
+    if not s.parameters:
+        raise ValueError("Expecting at least one parameter")
+    ret = s.return_annotation
+    if ret is s.empty:
+        ret = Any
+
+    p = next(iter(s.parameters.values()))
+    inp = p.annotation
+    if inp is s.empty:
+        inp = Any
+    return Annotated[ret, InputType(inp), Validator(func)]

--- a/validobj/tests/test_custom.py
+++ b/validobj/tests/test_custom.py
@@ -1,0 +1,48 @@
+import pytest
+import dataclasses
+from typing import Any
+
+try:
+    from validobj.custom import Parser, Validator, InputType
+except ImportError:  # pragma: nocover
+    HAVE_CUSTOM = False
+else:
+    HAVE_CUSTOM = True
+
+from validobj import parse_input, ValidationError
+
+
+@pytest.mark.skipif(not HAVE_CUSTOM, reason="Custom type not found")
+def test_custom():
+    def my_float(inp: str) -> float:
+        return float(inp) + 1
+
+    MyFloat = Parser(my_float)
+    assert MyFloat.__origin__ is float
+    assert isinstance(MyFloat.__metadata__[0], InputType)
+    assert isinstance(MyFloat.__metadata__[1], Validator)
+
+    @dataclasses.dataclass
+    class Container:
+        value: MyFloat
+
+    assert parse_input({"value": "5"}, Container) == Container(value=6)
+    with pytest.raises(ValidationError):
+        parse_input({"value": 5}, Container)
+
+
+@pytest.mark.skipif(not HAVE_CUSTOM, reason="Custom type not found")
+def test_no_annotations():
+    def my_float(inp):
+        return float(inp) + 1
+
+    MyFloat = Parser(my_float)
+    assert MyFloat.__origin__ is Any
+    assert parse_input(5, MyFloat) == 6.0
+
+@pytest.mark.skipif(not HAVE_CUSTOM, reason="Custom type not found")
+def test_bad_func():
+    def noparams() -> str:
+        return "wrong" # pragma: nocover
+    with pytest.raises(ValueError):
+        Parser(noparams)

--- a/validobj/tests/test_validation.py
+++ b/validobj/tests/test_validation.py
@@ -12,17 +12,17 @@ else:
 
 try:
     from types import UnionType
-except ImportError:
+except ImportError:  # pragma: nocover
     HAVE_UNION_TYPE = False
 else:
     HAVE_UNION_TYPE = True
 
 try:
     from typing import TypedDict
-except ImportError:
+except ImportError: #pragma: nocover
     HAVE_TYPED_DICT = False
 else:
-    HAVE_TYPED_DICT = sys.version_info[:2] >= (3, 9)
+    HAVE_TYPED_DICT = sys.version_info >= (3, 9)
 
 try:
     from typing import Annotated

--- a/validobj/validation.py
+++ b/validobj/validation.py
@@ -25,7 +25,7 @@ try:
 except ImportError: # pragma: nocover
     HAVE_TYPED_DICT = False
 else:
-    HAVE_TYPED_DICT = sys.version_info[:2] >= (3, 9)
+    HAVE_TYPED_DICT = sys.version_info >= (3, 9)
 
 try:
     from typing import _AnnotatedAlias
@@ -33,6 +33,7 @@ except ImportError: # pragma: nocover
     HAVE_ANNOTATED = False
 else:
     HAVE_ANNOTATED = True
+    from validobj.custom import InputType, Validator
 
 try:
     from types import UnionType
@@ -254,6 +255,11 @@ def _parse_enum(value, spec):
 
 
 def _parse_annotated(value, spec):
+    meta = spec.__metadata__
+    if len(meta) == 2 and isinstance(meta[0], InputType) and isinstance(meta[1], Validator):
+        inp, func = meta
+        parsed = parse_input(value, inp.type)
+        return func(parsed)
     return parse_input(value, spec.__origin__)
 
 


### PR DESCRIPTION
Use typing.Annotated to pass functions doing the validation as needed.
Add a facility to convert a validation function into an annotated
instance.