### PR TITLE
Use zero value for flag

### DIFF
--- a/validobj/validation.py
+++ b/validobj/validation.py
@@ -255,8 +255,7 @@ def _parse_single_enum(value, spec):
 
 
 def _parse_list_enum(value, spec):
-    # This is a hidden function to create an enum composition with no members
-    res = spec._create_pseudo_member_(0)
+    res = spec(0)
     for i, item in enumerate(value):
         try:
             res |= _parse_single_enum(item, spec)


### PR DESCRIPTION
Instead of hidden method that is inaccessible in Python 3.11.

Closes #8.